### PR TITLE
Path workaround for navigation into the laboratory

### DIFF
--- a/modules/r1Obr-orchestrator/nav2loc.cpp
+++ b/modules/r1Obr-orchestrator/nav2loc.cpp
@@ -105,6 +105,21 @@ bool Nav2Loc::go(string loc)
     if (loc == "home")
         return goHome();
 
+    // This piece of code will work with a specific locations.ini configuration
+    // Forcing a specific path following if we want to go to the laboratory from outside
+    if(loc == "laboratory")
+    {
+        if(!m_iNav2D->checkInsideArea("lab_area"))
+        {
+            if(!m_iNav2D->gotoTargetByLocationName("path_to_laboratory"))
+            {
+                yCError(NAV_2_LOC, "Error with navigation to lab area from outside");
+                return false;
+            }
+        }
+        // If we are inside the lab area, we swap to the default behaviour
+    }
+
     if(!m_iNav2D->gotoTargetByLocationName(loc))
     {
         yCError(NAV_2_LOC, "Error with navigation to home location");

--- a/modules/r1Obr-orchestrator/nav2loc.cpp
+++ b/modules/r1Obr-orchestrator/nav2loc.cpp
@@ -109,9 +109,9 @@ bool Nav2Loc::go(string loc)
     // Forcing a specific path following if we want to go to the laboratory from outside
     if(loc == "laboratory")
     {
-        if(!m_iNav2D->checkInsideArea("lab_area"))
+        if(!m_iNav2D->checkInsideArea("laboratory_area"))
         {
-            if(!m_iNav2D->gotoTargetByLocationName("path_to_laboratory"))
+            if(!m_iNav2D->gotoTargetByLocationName("laboratory_path"))
             {
                 yCError(NAV_2_LOC, "Error with navigation to lab area from outside");
                 return false;


### PR DESCRIPTION
I am adding this change as a draft since it requires more steps and it needs to be tested. However I think it might be more time consuming to test this in simulation rather than with the real robot.

### Todo
- If we wish, we could make this names custom in order to potentially reuse this logic. For the time being before testing I think it's ok to leave them here.
- [x] Define the area "lab area" in locations.ini. It should include also the corridor before the lab
- [x] Define the "path_to_laboratory" so that it has a pose just before the door and another inside the lab
- [x] Install the most recent versions of YARP and Navigation